### PR TITLE
feat: render one column when isSmallDevice

### DIFF
--- a/src/hooks/use-render.ts
+++ b/src/hooks/use-render.ts
@@ -1,4 +1,4 @@
-import { embed, stardust, useApp, useEffect, useElement, useLayout, useModel, useOptions, usePromise, useState, useConstraints } from "@nebula.js/stardust";
+import { embed, stardust, useApp, useEffect, useElement, useLayout, useModel, useOptions, usePromise, useState, useConstraints, useTranslator } from "@nebula.js/stardust";
 import { store, IStore } from '../store';
 import getListBoxResources from "./listbox/get-listbox-resources";
 import { IContainerElement, IListLayout, IListBoxOptions, IFilterPaneLayout, IListboxResource, ListboxResourcesArr } from './types';
@@ -9,11 +9,13 @@ import { IEnv } from '../types/types';
 interface IUseOptions {
   listboxOptions?: IListBoxOptions;
   zoomSelf?: () => void;
+  isZoomed?: boolean;
 }
 
 export default function useRender({ flags, sense }: IEnv) {
   const options = useOptions() as IUseOptions;
   const constraints = useConstraints();
+  const translator = useTranslator();
   const { isEnabled } = flags;
 
   const [resourcesArr, setResourcesArr] = useState<IListboxResource[] | undefined>(undefined);
@@ -22,7 +24,11 @@ export default function useRender({ flags, sense }: IEnv) {
   const model = useModel();
   const layout = useLayout() as IFilterPaneLayout;
 
-  store.setState({ app, model, layout });
+  store.setState({
+    app,
+    model,
+    isSmallDevice: sense?.isSmallDevice,
+  });
 
   const containerElement = <IContainerElement>useElement();
 
@@ -46,11 +52,13 @@ export default function useRender({ flags, sense }: IEnv) {
         listboxOptions: options.listboxOptions ?? {},
         resources: resourcesArr,
         onFullscreen: options.zoomSelf,
+        isZoomed: options.isZoomed,
         constraints,
+        t: translator,
       },
     );
     return (() => {
       teardown(root);
     });
-  }, [resourcesArr, constraints]);
+  }, [resourcesArr, constraints, options.isZoomed]);
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -15,6 +15,5 @@ export interface IStore {
 export const store = createVanilla(() => ({
   app: <EngineAPI.IApp | undefined>undefined,
   model: <EngineAPI.IGenericObject | undefined>undefined,
+  isSmallDevice: <(() => boolean) | undefined>undefined,
 }));
-
-


### PR DESCRIPTION
- When `isSmallDevice` it true, only render one column with collapsed Listboxes.
- When `isZoomed` is true and all items don't fit, inform user.
- Only export functions in distribute-resources.ts that are used outside of distribute-resources.ts.
- Remove case for `zoomEnabled`, always shrink container and show "..."-button if Listboxes doesn't fit. The "..."-button will show Listboxes in a popover later on.