### PR TITLE
feat: make collapsed Listboxes smaller

### DIFF
--- a/src/components/FoldedListbox.tsx
+++ b/src/components/FoldedListbox.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@mui/material';
 import React from 'react';
 import { IListLayout } from '../hooks/types';
 import useFieldName from '../hooks/use-field-name';
+import { COLLAPSED_HEIGHT } from './ListboxGrid/distribute-resources';
 
 export interface FoldedListboxProps {
   layout: IListLayout;
@@ -13,9 +14,9 @@ export const FoldedListbox = ({ layout }: FoldedListboxProps) => {
 
   return (
     <Typography
-      variant="h6"
+      variant="subtitle2"
       border="1px solid lightgrey"
-      padding="8px"
+      height={COLLAPSED_HEIGHT - 2}
     >
       {fieldName}
     </Typography>

--- a/src/components/ListboxContainer.tsx
+++ b/src/components/ListboxContainer.tsx
@@ -61,6 +61,7 @@ const ListboxContainer = ({
         height='100%'
         border='1px solid lightgrey'
         borderBottom={borderBottom ? '1px solid lightgrey' : 0}
+        borderRadius='4px'
         ref={elRef}
       />
     </>

--- a/src/components/ListboxContainer.tsx
+++ b/src/components/ListboxContainer.tsx
@@ -10,10 +10,11 @@ interface ListboxContainerProps {
   app?: EngineAPI.IApp;
   listboxOptions: IListBoxOptions;
   constraints?: IConstraints;
+  borderBottom?: boolean;
 }
 
 const ListboxContainer = ({
-  layout, app, constraints, listboxOptions,
+  layout, app, constraints, listboxOptions, borderBottom,
 }: ListboxContainerProps) => {
   const [listboxInstance, setListboxInstance] = useState<stardust.FieldInstance>();
   const elRef = useRef<HTMLElement>();
@@ -59,6 +60,7 @@ const ListboxContainer = ({
       <Box
         height='100%'
         border='1px solid lightgrey'
+        borderBottom={borderBottom ? '1px solid lightgrey' : 0}
         ref={elRef}
       />
     </>

--- a/src/components/ListboxGrid/ListboxGrid.tsx
+++ b/src/components/ListboxGrid/ListboxGrid.tsx
@@ -12,7 +12,7 @@ import ListboxContainer from '../ListboxContainer';
 import 'react-resizable/css/styles.css';
 import ElementResizeListener from '../ElementResizeListener';
 import {
-  setDefaultValues, balanceColumns, calculateColumns, calculateExpandPriority, COLLAPSED_HEIGHT, mergeColumnsAndResources,
+  setDefaultValues, balanceColumns, calculateColumns, calculateExpandPriority, mergeColumnsAndResources,
 } from './distribute-resources';
 import { FoldedListbox } from '../FoldedListbox';
 import { ExpandButton } from '../ExpandButton';
@@ -79,16 +79,26 @@ export default function ListboxGrid(props: ListboxGridProps) {
         wrapper={(children: JSX.Element[]) => <Resizable width={1080} height={1000} minConstraints={[10, 10]} maxConstraints={[1220, 1820]}>{children}</Resizable>}
       >
         <ElementResizeListener onResize={dHandleResize} />
-        <Grid container columns={columns?.length} ref={gridRef as any} spacing={1} height='100%'>
+        <Grid container columns={columns?.length} ref={gridRef as any} spacing={0} height='100%'>
 
           {!!columns?.length && columns?.map((column: IColumn, i: number) => (
             <ColumnGrid key={i} widthPercent={100 / columns.length}>
-              <Column>
+              <Column lastColumn={columns.length === i + 1}>
 
-                {!!column?.items?.length && column.items.map((item: IListboxResource) => (
-                  <ColumnItem key={item.id} height={item.expand ? item.height : COLLAPSED_HEIGHT}>
+                {!!column?.items?.length && column.items.map((item: IListboxResource, j: number) => (
+                  <ColumnItem
+                    key={item.id}
+                    lastItem={column.items?.length === j + 1}
+                    listItem={item}
+                  >
                     {item.expand
-                      ? <ListboxContainer layout={item.layout} app={app} listboxOptions={listboxOptions} constraints={constraints}></ListboxContainer>
+                      ? <ListboxContainer
+                        layout={item.layout}
+                        app={app}
+                        listboxOptions={listboxOptions}
+                        constraints={constraints}
+                        borderBottom={(column.items?.length === j + 1) || !item.fullyExpanded}
+                      ></ListboxContainer>
                       : <FoldedListbox layout={item.layout}></FoldedListbox>
                     }
                   </ColumnItem>

--- a/src/components/ListboxGrid/distribute-resources.ts
+++ b/src/components/ListboxGrid/distribute-resources.ts
@@ -2,16 +2,16 @@ import { IListboxResource } from '../../hooks/types';
 import { store } from '../../store';
 import { IColumn, ISize } from './interfaces';
 
-export const COLLAPSED_HEIGHT = 58;
+export const COLLAPSED_HEIGHT = 34;
 export const BUTTON_HEIGHT = 50;
 const BUTTON_SPACING = 8;
-const ITEM_SPACING = 0;
+export const ITEM_SPACING = 8;
 const EXPANDED_HEIGHT = 140;
 const COLUMN_MIN_WIDTH = 160;
 const COLUMN_SPACING = 16;
-const EXPANDED_HEADER_HEIGHT = 64;
-const EXPANDED_ROW_HEIGHT = 32;
-const SEARCH_BAR = 40;
+const EXPANDED_HEADER_HEIGHT = 50;
+const EXPANDED_ROW_HEIGHT = 33;
+const SEARCH_BAR = 42;
 const sm = () => {
   const { isSmallDevice } = store.getState();
   return isSmallDevice?.();
@@ -41,10 +41,7 @@ const getHeightOf = (collapsedItemCount: number) => {
 
 const getDimensionCardinal = (item: IListboxResource) => item.layout.qListObject.qDimensionInfo.qCardinal;
 
-const getHeightOfExpanded = (dimensionCardinal: number) => {
-  const height = dimensionCardinal * EXPANDED_ROW_HEIGHT + EXPANDED_HEADER_HEIGHT + SEARCH_BAR + 3;
-  return height;
-};
+const getHeightOfExpanded = (dimensionCardinal: number) => dimensionCardinal * EXPANDED_ROW_HEIGHT + EXPANDED_HEADER_HEIGHT + SEARCH_BAR + 4;
 
 const doesAllFit = (itemsPerColumn: number, columnCount: number, itemCount: number) => itemCount <= itemsPerColumn * columnCount;
 
@@ -135,6 +132,13 @@ export const mergeColumnsAndResources = (columns: IColumn[], resources: IListbox
   return columns;
 };
 
+const setFullyExpanded = (item: IListboxResource) => {
+  if (parseFloat(item.height) >= getHeightOfExpanded(item.cardinal)) {
+    item.height = `${getHeightOfExpanded(item.cardinal)}px`;
+    item.fullyExpanded = true;
+  }
+};
+
 const expandOne = (sortedItems: IListboxResource[] | undefined, h: number) => {
   if (!sortedItems) return false;
   let i;
@@ -148,6 +152,7 @@ const expandOne = (sortedItems: IListboxResource[] | undefined, h: number) => {
       if (expandedHeight < h) {
         item.expand = true;
         item.height = `${expandedHeight}px`;
+        setFullyExpanded(item);
         return expandedHeight + ITEM_SPACING;
       }
     }
@@ -193,16 +198,16 @@ export const calculateExpandPriority = (columns: IColumn[], size: ISize) => {
       const collapsedItems = sortedItems?.filter((item) => !item.expand);
 
       if (leftOverHeight > EXPANDED_HEIGHT && collapsedItems?.length) {
-        const item = collapsedItems[0]; // Only add spacing if there are more items after this.
-        const spacing = collapsedItems.length > 1 ? ITEM_SPACING : 0;
+        const item = collapsedItems[0];
 
         if (!item.expand) {
           if ((sortedItems?.length ?? 0) > 1) {
             // Should only set specific height when multiple items in columns, otherwise 100% height from default value
-            item.height = `${size.height - getHeightOf(collapsedItems.length - 1) - totalExpandedHeight - spacing}px`;
+            item.height = `${size.height - getHeightOf(collapsedItems.length - 1) - totalExpandedHeight}px`;
           }
           item.expand = true;
         }
+        setFullyExpanded(item);
       }
     }
 
@@ -219,5 +224,6 @@ export const calculateExpandPriority = (columns: IColumn[], size: ISize) => {
 export const setDefaultValues = (resources: IListboxResource[]) => resources.map((resource: IListboxResource) => {
   resource.expand = false;
   resource.height = '100%';
+  resource.fullyExpanded = false;
   return resource;
 });

--- a/src/components/ListboxGrid/distribute-resources.ts
+++ b/src/components/ListboxGrid/distribute-resources.ts
@@ -223,7 +223,7 @@ export const calculateExpandPriority = (columns: IColumn[], size: ISize) => {
 
 export const setDefaultValues = (resources: IListboxResource[]) => resources.map((resource: IListboxResource) => {
   resource.expand = false;
-  resource.height = '100%';
+  resource.height = 'calc(100% - 2px)';
   resource.fullyExpanded = false;
   return resource;
 });

--- a/src/components/ListboxGrid/grid-components/Column.tsx
+++ b/src/components/ListboxGrid/grid-components/Column.tsx
@@ -9,7 +9,7 @@ export interface ColumnProps {
 export const Column = ({ children, lastColumn }: ColumnProps) => (
   <Box
     height='100%'
-    paddingRight={lastColumn ? undefined : '8px'}
+    paddingRight={lastColumn ? '0px' : '8px'}
   >
     {children}
   </Box>

--- a/src/components/ListboxGrid/grid-components/Column.tsx
+++ b/src/components/ListboxGrid/grid-components/Column.tsx
@@ -3,10 +3,14 @@ import React from 'react';
 
 export interface ColumnProps {
   children: React.ReactNode,
+  lastColumn: boolean,
 }
 
-export const Column = ({ children }: ColumnProps) => (
-  <Box height='100%'>
+export const Column = ({ children, lastColumn }: ColumnProps) => (
+  <Box
+    height='100%'
+    paddingRight={lastColumn ? undefined : '8px'}
+  >
     {children}
   </Box>
 );

--- a/src/components/ListboxGrid/grid-components/ColumnItem.tsx
+++ b/src/components/ListboxGrid/grid-components/ColumnItem.tsx
@@ -1,13 +1,45 @@
 import { Grid } from '@mui/material';
 import React from 'react';
+import { IListboxResource } from '../../../hooks/types';
+import { COLLAPSED_HEIGHT, ITEM_SPACING } from '../distribute-resources';
 
 export type ColumnItemProps = {
-  height: string | number,
+  height?: string | number,
   children: React.ReactNode,
+  listItem?: IListboxResource,
+  lastItem?: boolean,
 }
 
-export const ColumnItem = ({ height, children, ...rest }: ColumnItemProps) => (
-  <Grid item height={height} paddingTop='8px' width='100%' {...rest}>
-    {children}
-  </Grid>
-);
+export const ColumnItem = ({
+  height,
+  children,
+  listItem,
+  lastItem,
+  ...rest
+}: ColumnItemProps) => {
+  const getPaddingBottom = () => {
+    if (listItem?.expand && !lastItem) {
+      return '8px';
+    }
+    return '0px';
+  };
+
+  const getHeight = () => {
+    if (height) {
+      return height;
+    }
+    return listItem?.expand ? listItem?.height : COLLAPSED_HEIGHT + ITEM_SPACING;
+  };
+
+  return (
+    <Grid
+      item
+      height={getHeight()}
+      paddingTop='0px'
+      width='100%'
+      paddingBottom={getPaddingBottom()}
+      {...rest}>
+      {children}
+    </Grid>
+  );
+};

--- a/src/hooks/types/index.d.ts
+++ b/src/hooks/types/index.d.ts
@@ -53,6 +53,7 @@ export interface IListboxResource {
   expand: boolean;
   cardinal: number;
   responsiveMode: string;
+  fullyExpanded: boolean;
 }
 
 export type ListboxResourcesArr = array & IListboxResource[];


### PR DESCRIPTION
Make collapsed Listboxes the same size as the old filter-pane.
Don't use spacing in Mui grid, set item spacing manually.